### PR TITLE
Bug fixes for mapStateToProps

### DIFF
--- a/app/util/mapStateToProps.js
+++ b/app/util/mapStateToProps.js
@@ -15,8 +15,8 @@ export default mapper => Component => compose({
   componentWillMount () {
     const syncState = () => {
       const newProps = mapper(getState())
-      if (!equal(newProps, this.state)) {
-        this.setState({...newProps})
+      if (!equal(newProps, this.state._namespacedState)) {
+        this.setState({_namespacedState: newProps})
       }
     }
     syncState()
@@ -25,7 +25,7 @@ export default mapper => Component => compose({
   componentWillUnmount () {
     this.unsubscribe()
   },
-  render (props) {
-    return <Component {...props} />
+  render ({unsubscribe, _namespacedState, ...props}) {
+    return <Component {...props} {..._namespacedState} />
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3155,7 +3155,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -3572,7 +3573,8 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",


### PR DESCRIPTION
- Namespace local component state so that entire state is replaced when mapped props are different than current state.
- Remove unsubscribe function from props (I think compose is adding it)